### PR TITLE
WIP :boom: indexing

### DIFF
--- a/src/interfaces/collection-config.interface.ts
+++ b/src/interfaces/collection-config.interface.ts
@@ -1,6 +1,7 @@
 import { IColumnConfig } from './column-config.interface';
+import { IIndexConfig } from './index-config.interface';
 
 export interface ICollectionConfig {
   columns: Array<IColumnConfig>;
-  indexes: Array<string>;
+  indexes: Array<IIndexConfig>;
 }

--- a/src/interfaces/index-config.interface.ts
+++ b/src/interfaces/index-config.interface.ts
@@ -1,0 +1,6 @@
+export interface IIndexConfig {
+    column: string;
+    type?: string;//tbc 
+    unique: boolean;
+    name: string;
+}

--- a/src/modules/persistence/indexeddb/__tests__/indexeddb-persistence.test.ts
+++ b/src/modules/persistence/indexeddb/__tests__/indexeddb-persistence.test.ts
@@ -1,4 +1,5 @@
 import { ICamaConfig } from "../../../../interfaces/cama-config.interface";
+import { ICollectionConfig } from "../../../../interfaces/collection-config.interface";
 import { ILogger } from "../../../../interfaces/logger.interface";
 import { PersistenceAdapterEnum } from "../../../../interfaces/perisistence-adapter.enum";
 import IndexedDbPersistence from "../indexeddb-persistence";
@@ -10,14 +11,38 @@ describe("IndexedDbPersistence", () => {
 
   let indexedDbPersistence: IndexedDbPersistence;
 
+  const mockCollectionConfig: ICollectionConfig = {
+    indexes: [
+      { name: 'index1', column: 'column1', unique: false },
+      { name: 'index2', column: 'column2', unique: true },
+    ],
+    columns: []
+  };
+  
   beforeEach(() => {
-    indexedDbPersistence = new IndexedDbPersistence(mockConfig, mockLogger, mockCollectionName);
+    indexedDbPersistence = new IndexedDbPersistence(mockConfig, mockLogger, mockCollectionName, mockCollectionConfig);
   });
 
-  afterEach(() => {
-    indexedDbPersistence.destroy();
-  });
 
+  describe("indexes", () => {
+    it("should create indexes in the object store", async () => {
+      await indexedDbPersistence.update([]); // Ensure the database is initialized
+  
+      //@ts-ignore
+      const tx = indexedDbPersistence.db.transaction(mockCollectionName, 'readonly');
+      const store = tx.objectStore(mockCollectionName);
+  
+      const indexNames = Array.from(store.indexNames);
+  
+      expect(indexNames.length).toBe(mockCollectionConfig.indexes.length);
+  
+      for (const indexConfig of mockCollectionConfig.indexes) {
+        expect(indexNames).toContain(indexConfig.name);
+        const index = store.index(indexConfig.name);
+        expect(index.unique).toBe(indexConfig.unique);
+      }
+    });
+  });
   describe("getData", () => {
     it("should get data from IndexedDB", async () => {
       const data = ["test-data-1", "test-data-2", "test-data-3"];


### PR DESCRIPTION
IndexedDB requires a bit more configuration than the current implementation of an array of strings - this has been updated to use the fields unique, name, column and type.

Type is optional as there's no specification for this at present, but as we move onto the other adapters, more configuration is needed